### PR TITLE
Use bash as shell interpreter

### DIFF
--- a/generate-data.sh
+++ b/generate-data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/start-dbchain.sh
+++ b/start-dbchain.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Some Linux distros like Debian/Ubuntu symlink `/bin/sh` to `dash` instead of `bash`. The problem being `set -o pipefail` is not POSIX-compliant and so `dash` doesn't support it.
As a result both scripts fail to run on aforementioned distros.

* use `bash` as shell interpreter