### PR TITLE
Use HTTPS URL for blockscout-rs-neti submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Golem-Base/golembase-op-geth.git
 [submodule "blockscout-rs-neti"]
 	path = blockscout-rs-neti
-	url = git@github.com:Golem-Base/blockscout-rs-neti.git
+	url = https://github.com/Golem-Base/blockscout-rs-neti.git


### PR DESCRIPTION
Unless there's a good reason not to do it i suggest switching to HTTPS URL for `blockscout-rs-neti` submodule.
Currently it's using SSH to fetch it and this becomes a bit problematic in practice on non-development matchines and in VMs.

* use HTTPS URL for `blockscout-rs-neti` submodule