### PR TITLE
Bind rpclorer to port 9000

### DIFF
--- a/golembase-op-geth-rpclorer-external-port.diff
+++ b/golembase-op-geth-rpclorer-external-port.diff
@@ -1,0 +1,13 @@
+diff --git a/docker-compose.yml b/docker-compose.yml
+index 891e0b8b6..237a036dc 100644
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -126,7 +126,7 @@ services:
+       op-geth:
+         condition: service_healthy
+     ports:
+-      - "8080:8080"
++      - "9000:8080"
+     environment:
+       - NODE_URL=http://op-geth:8545
+     restart: on-failure 

--- a/start-dbchain.sh
+++ b/start-dbchain.sh
@@ -20,5 +20,5 @@ go build -o golembase
 ./golembase account fund
 
 echo
-echo "Running. Visit http://localhost:8080/ to verify."
+echo "Running. Visit http://localhost:9000/ to verify."
 echo "RPC endpoint available at http://localhost:8545 and ws://localhost:8545"

--- a/start-dbchain.sh
+++ b/start-dbchain.sh
@@ -11,6 +11,7 @@ cargo build
 
 cd ../../golembase-op-geth
 patch -N < ../golembase-op-geth-enable-txpool-api.diff || true
+patch -N < ../golembase-op-geth-rpclorer-external-port.diff || true
 docker compose up -d
 
 cd cmd/golembase


### PR DESCRIPTION
Our current setup binds `rpclorer` to port 8080. This conflicts with our `blockscout` instance.

* patch `docker-compose.yml` to bind `rpclorer` to port 9000